### PR TITLE
FLUID-6324: use @waharnum's fork of docpad-plugin-handlebars

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "dependencies": {
         "docpad": "6.82.5",
-        "docpad-plugin-handlebars": "2.5.0",
+        "docpad-plugin-handlebars": "github:waharnum/docpad-plugin-handlebars#fixFor6.8",
         "docpad-plugin-highlightjs": "2.6.0",
         "docpad-plugin-marked": "2.5.0",
         "fs-extra": "7.0.1",


### PR DESCRIPTION
I've fixed the Handlebars plugin for the 6.82.x line of Docpad.

I will open a pull request to the plug-in to discuss my fix and potentially get it merged upstream, but for now this allows the docs site to be generated with the 6.82.x line of Docpad.

My PR at https://github.com/docpad/docpad-plugin-handlebars/pull/13 - we can update our use of the plugin should that get merged.